### PR TITLE
fix: reject dot path segments

### DIFF
--- a/docker_v3_connector.py
+++ b/docker_v3_connector.py
@@ -30,6 +30,7 @@ from phantom.base_connector import BaseConnector
 
 # Usage of the consts file is recommended
 from docker_v3_consts import *
+from docker_validation import validate_endpoint_path
 
 
 class RetVal(tuple):
@@ -172,6 +173,11 @@ class Docker_V3Connector(BaseConnector):
         # **kwargs can be any additional
         # parameters that requests.request accepts
 
+        try:
+            validate_endpoint_path(endpoint)
+        except ValueError as exc:
+            return RetVal(action_result.set_status(phantom.APP_ERROR, str(exc)), None)
+
         config = self.get_config()
 
         resp_json = None
@@ -203,6 +209,11 @@ class Docker_V3Connector(BaseConnector):
     def _make_post_call(self, endpoint, action_result, method="post", **kwargs):
         # **kwargs can be any additional
         # parameters that requests.request accepts
+
+        try:
+            validate_endpoint_path(endpoint)
+        except ValueError as exc:
+            return RetVal(action_result.set_status(phantom.APP_ERROR, str(exc)), None)
 
         config = self.get_config()
 

--- a/docker_validation.py
+++ b/docker_validation.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validation helpers for Docker API endpoints."""
+
+
+def validate_endpoint_path(endpoint: str) -> None:
+    """Reject path-normalization segments before dispatching a Docker API request."""
+    path = endpoint.split("?", 1)[0].split("#", 1)[0]
+    if any(segment in {".", ".."} for segment in path.split("/")):
+        raise ValueError("Docker API endpoint contains a dot path segment")

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Rejected exact dot segments before dispatching Docker API requests

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from docker_validation import validate_endpoint_path
+
+
+class ValidateEndpointPathTests(unittest.TestCase):
+    def test_accepts_normal_resource_paths(self):
+        for endpoint in (
+            "/containers/abc/json",
+            "/images/library%2Falpine/history",
+            "/containers/json?filters=label%3Dexample",
+        ):
+            with self.subTest(endpoint=endpoint):
+                validate_endpoint_path(endpoint)
+
+    def test_rejects_exact_dot_segments(self):
+        for endpoint in (
+            "/containers/./json",
+            "/containers/../json",
+            "/images/../swarm/history",
+            "/containers/./json?size=true",
+        ):
+            with self.subTest(endpoint=endpoint), self.assertRaises(ValueError):
+                validate_endpoint_path(endpoint)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Reject exact `.` and `..` path segments at the shared Docker request boundary before GET, POST, or DELETE dispatch.
- Preserve encoded ordinary container and image identifiers while preventing request path normalization from changing the selected API resource.
- Add focused regression tests for normal resource paths and exact-dot variants.

## Tracking

- [PAPP-38163](https://splunk.atlassian.net/browse/PAPP-38163)
- [PSAAS-30965](https://splunk.atlassian.net/browse/PSAAS-30965)
- [VULN-93690](https://splunk.atlassian.net/browse/VULN-93690)
- Parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)
- Follow-up to merged PR #4.

## Quality gate

- `python3 -m unittest discover -s tests -v`: 2 passed
- Connector lint, formatting, app lint, documentation, notice, release-note, and static checks pass locally.
- Local Semgrep could not initialize the sandbox CA trust store; hosted pre-commit and compile gates are pending.

This pull request and its text were prepared by Codex with AI assistance.
